### PR TITLE
Work around problems with file separators when running on windows.

### DIFF
--- a/src/main/groovy/de/lisaplus/atlas/codegen/java/JavaGeneratorBase.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/codegen/java/JavaGeneratorBase.groovy
@@ -20,7 +20,8 @@ abstract class JavaGeneratorBase extends MultiFileGenarator {
     @Override
     String getDestDir(Model dataModel, String outputBasePath, Map<String, String> extraParameters, Type currentType=null) {
         String destDirBase = extraParameters.outputDirExt ? outputBasePath + File.separator + extraParameters.outputDirExt : outputBasePath
-        String packageStr = extraParameters.packageName ? extraParameters.packageName.replaceAll('\\.',File.separator) : ''
+        // Force linux/unix file separator, JVM can handle that on all plattforms!
+        String packageStr = extraParameters.packageName ? extraParameters.packageName.replaceAll('\\.','/') : ''
         String destDirStr = "${destDirBase}${File.separator}${packageStr}"
         File destDir = new File(destDirStr)
         if (!destDir.exists()) destDir.mkdirs()

--- a/src/test/groovy/de/lisaplus/atlas/builder/test/jsonschema/JsonSchemaBuilder.groovy
+++ b/src/test/groovy/de/lisaplus/atlas/builder/test/jsonschema/JsonSchemaBuilder.groovy
@@ -40,7 +40,8 @@ class JsonSchemaBuilder {
         println "name: ${f.getName()}"
         */
         def s = de.lisaplus.atlas.builder.JsonSchemaBuilder.getBasePathFromModelFile(f)
-        assertEquals('src/test/resources/test_schemas/',s)
+        def s2 = s.replaceAll('\\\\','/') // convert windows file separator to linux/unix file separator 
+        assertEquals('src/test/resources/test_schemas/',s2)
     }
 
     @Test


### PR DESCRIPTION
Befehle:
git clone git@github.com:SpeedsterF2/jsoncodegen.git
git remote add upstream https://github.com/schlothauer-wauer/jsoncodegen.git
git branch windows_workarounds
git checkout windows_workarounds
git add src*
git commit -m "Work around problems with file separators when running on windows."
git push --set-upstream origin windows_workarounds

PR aus github.com heraus initialisiert!