### PR TITLE
handle tags added to array properties.

### DIFF
--- a/src/main/groovy/de/lisaplus/atlas/builder/JsonSchemaBuilder.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/builder/JsonSchemaBuilder.groovy
@@ -183,6 +183,9 @@ class JsonSchemaBuilder implements IModelBuilder {
                 newType.properties.addAll(tmp.type.properties)
                 newType.baseTypes.add(tmp.type.name)
             }
+            else if (typeObj.value.'__tags') {
+                newType.tags=typeObj.value.'__tags'
+            }
             else {
                 newType.properties = getProperties(model,typeObj.value,typeName,currentSchemaPath)
             }


### PR DESCRIPTION
For flagging arrays containing objects of the parent type, e.g.
"references": {
          "type": "array",
          "__tags": ["recursion"],
          "items": {
            "type": "string",
            "format": "uuid",
            "__ref": "#/definitions/OpMessage"
          }
        }