### PR TITLE
Better handle collections & enums in java  generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ gradle myRun -PmyArgs="-o,/tmp/test_beans,-m,src/test/resources/test_schemas/mul
 -gp,destFileNameExt=java,-gp,packageName=de.sw.atlas.test"
 ```
 ### Usage of the release
+**First download [the latest release from here](https://github.com/kaiso/jsoncodegen/releases/download/v0.13.3/jsonCodeGen-v0.13.3.zip)**
 
 ```bash
 ./jsonCodeGen.sh

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = 8
 def mainClass='de.lisaplus.atlas.DoCodeGen'
 
 project.group = 'de.lisaplus.tools'
-project.version = '0.13.2'
+project.version = '0.13.3'
 
 
 task sourcesJar(type: Jar) {
@@ -49,9 +49,11 @@ task dependenciesToLibDir(type: Copy) {
     from configurations.runtime
 }
 
-task buildRelease (type: Copy) {
+task buildRelease {
+    outputs.upToDateWhen { false }
+    doLast {
         println 'buildRelease start ...'
-        outputs.upToDateWhen { false }
+        
 
         copy {
             from "${project.rootDir}/src/main/resources/bin"
@@ -62,11 +64,14 @@ task buildRelease (type: Copy) {
             into "${buildDir}/release/conf"
         }
 
-
-        into "${buildDir}/release/lib"
-        from "${buildDir}/libs"
+        copy {
+          into "${buildDir}/release/lib"
+          from "${buildDir}/libs"
+          
+        }
 
         println 'buildRelease end ...'
+    }
 }
 
 task zipRelease (type: Zip) {

--- a/local-storage.json
+++ b/local-storage.json
@@ -1,0 +1,1 @@
+{"anonymousUserId":"ca1b5dec-2f6a-4248-87c9-facf84e71b38"}

--- a/src/main/groovy/de/lisaplus/atlas/builder/JsonSchemaBuilder.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/builder/JsonSchemaBuilder.groovy
@@ -483,7 +483,6 @@ class JsonSchemaBuilder implements IModelBuilder {
             throw new Exception(errorMsg)
         }
         String enumTypeName = propertiesParent."__enumName" ? propertiesParent."__enumName" : baseTypeName
-
         def allowedValues = propertiesParent."enum"
 
         def alreadyCreated = createdTypes[enumTypeName]

--- a/src/main/groovy/de/lisaplus/atlas/codegen/helper/java/JavaTypeConvert.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/codegen/helper/java/JavaTypeConvert.groovy
@@ -45,29 +45,29 @@ class JavaTypeConvert {
         }
         switch(type.name()) {
             case IntType.NAME:
-                return type.isArray? 'java.util.List<Integer>' : 'Integer'
+                return type.isArray? 'java.util.Collection<? extends Integer>' : 'Integer'
             case LongType.NAME:
-                return type.isArray? 'java.util.List<Long>' : 'Long'
+                return type.isArray? 'java.util.Collection<? extends Long>' : 'Long'
             case NumberType.NAME:
-                return type.isArray? 'java.util.List<Double>' : 'Double'
+                return type.isArray? 'java.util.Collection<? extends Double>' : 'Double'
             case StringType.NAME:
-                return type.isArray? 'java.util.List<String>' : 'String'
+                return type.isArray? 'java.util.Collection<? extends String>' : 'String'
             case UUIDType.NAME:
-                return type.isArray? 'java.util.List<UUID>' : 'UUID'
+                return type.isArray? 'java.util.Collection<? extends UUID>' : 'UUID'
             case BooleanType.NAME:
-                return type.isArray? 'java.util.List<Boolean>' : 'Boolean'
+                return type.isArray? 'java.util.Collection<? extends Boolean>' : 'Boolean'
             case ByteType.NAME:
-                return type.isArray? 'java.util.List<Byte>' : 'Byte'
+                return type.isArray? 'java.util.Collection<? extends Byte>' : 'Byte'
             case DateType.NAME:
-                return type.isArray? "java.util.List<${preset.dateClass}>" : "${preset.dateClass}"
+                return type.isArray? "java.util.Collection<? extends ${preset.dateClass}>" : "${preset.dateClass}"
             case DateTimeType.NAME:
-                return type.isArray? "java.util.List<${preset.dateTimeClass}>" : "${preset.dateTimeClass}"
+                return type.isArray? "java.util.Collection<? extends ${preset.dateTimeClass}>" : "${preset.dateTimeClass}"
             case RefType.NAME:
-                return type.isArray? "java.util.List<${prefix}${firstUpperCamelCase(type.type.name)}>" : "${prefix}${firstUpperCamelCase(type.type.name)}"
+                return type.isArray? "java.util.Collection<? extends ${prefix}${firstUpperCamelCase(type.type.name)}>" : "${prefix}${firstUpperCamelCase(type.type.name)}"
             case ComplexType.NAME:
-                return type.isArray? "java.util.List<${prefix}${firstUpperCamelCase(type.type.name)}>" : "${prefix}${firstUpperCamelCase(type.type.name)}"
+                return type.isArray? "java.util.Collection<? extends ${prefix}${firstUpperCamelCase(type.type.name)}>" : "${prefix}${firstUpperCamelCase(type.type.name)}"
             case ArrayType.NAME:
-                String base = "java.util.List<%s>";
+                String base = "java.util.Collection<? extends %s>";
                 BaseType aktType = type;
                 String ret = base;
                 String baseTypeStr = convert.call (type.baseType)

--- a/src/main/groovy/de/lisaplus/atlas/codegen/java/JavaInterfaceGenerator.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/codegen/java/JavaInterfaceGenerator.groovy
@@ -3,7 +3,6 @@ package de.lisaplus.atlas.codegen.java
 import de.lisaplus.atlas.codegen.TemplateType
 import de.lisaplus.atlas.model.Model
 import de.lisaplus.atlas.model.Type
-import de.lisaplus.atlas.model.EnumType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -17,7 +16,7 @@ class JavaInterfaceGenerator extends JavaGeneratorBase {
     @Override
     String getDestFileName(Model dataModel, Map<String, String> extraParameters, Type currentType=null) {
         String fileNameBase = firstUpperCase(currentType.name)
-        if (currentType instanceof EnumType) {
+        if (currentType.isEnum) {
             return "${ fileNameBase }.java"
         } else {
             return "I${fileNameBase}.java"

--- a/src/main/groovy/de/lisaplus/atlas/codegen/java/JavaInterfaceGenerator.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/codegen/java/JavaInterfaceGenerator.groovy
@@ -3,6 +3,7 @@ package de.lisaplus.atlas.codegen.java
 import de.lisaplus.atlas.codegen.TemplateType
 import de.lisaplus.atlas.model.Model
 import de.lisaplus.atlas.model.Type
+import de.lisaplus.atlas.model.EnumType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -10,16 +11,21 @@ import org.slf4j.LoggerFactory
  * Created by eiko on 05.06.17.
  */
 class JavaInterfaceGenerator extends JavaGeneratorBase {
-    private static final Logger log=LoggerFactory.getLogger(JavaInterfaceGenerator.class)
+
+    private static final Logger log = LoggerFactory.getLogger(JavaInterfaceGenerator.class)
 
     @Override
     String getDestFileName(Model dataModel, Map<String, String> extraParameters, Type currentType=null) {
         String fileNameBase = firstUpperCase(currentType.name)
-        return "I${fileNameBase}.java"
+        if (currentType instanceof EnumType) {
+            return "${ fileNameBase }.java"
+        } else {
+            return "I${fileNameBase}.java"
+        }
     }
 
     void initTemplate() {
-        template = createTemplateFromResource('templates/java/interface.txt',TemplateType.GString)
+        template = createTemplateFromResource('templates/java/interface.txt', TemplateType.GString)
     }
 
     Logger getLogger() {

--- a/src/main/groovy/de/lisaplus/atlas/model/Type.groovy
+++ b/src/main/groovy/de/lisaplus/atlas/model/Type.groovy
@@ -63,6 +63,17 @@ class Type {
      */
     boolean onlyBaseType=false
 
+
+    /**
+     * defines whether this type is an Enum
+     */
+    boolean isEnum=false
+
+    /**
+     * allowed values in case of Enum
+     */
+    String[] allowedValues=[]
+
     /**
      * array of free definable strings to add keywords to types and attributes.
      * This keywords can be used to select or deselect types or attributes while code generation
@@ -102,6 +113,8 @@ class Type {
         this.refOwner = source.refOwner == null ? null : source.refOwner.collect { owner -> Type.copyOf(owner, typeCopies)}
         this.onlyBaseType = source.onlyBaseType
         this.tags = source.tags== null ? null : new ArrayList<>(source.tags)
+        this.isEnum = source.isEnum
+        this.allowedValues = source.allowedValues
     }
 
     String toString() {
@@ -119,6 +132,8 @@ class Type {
         this.description = t.description
         this.requiredProps = t.requiredProps
         this.sinceVersion = t.sinceVersion
+        this.isEnum = t.isEnum
+        this.allowedValues = t.allowedValues
     }
 
     /**
@@ -237,10 +252,3 @@ class ExternalType extends Type {
     }
 }
 
-/**
- * type that implements enums
- */
-class EnumType extends Type {
-    // defined values for that enum
-    String[] allowedValues=[]
-}

--- a/src/main/resources/conf/logback.xml
+++ b/src/main/resources/conf/logback.xml
@@ -20,7 +20,7 @@
 	</appender>
 
 	<root level="info">
-		<appender-ref ref="FILE" />
+		<appender-ref ref="STDOUT" />
 	</root>
 
 </configuration>

--- a/src/main/resources/templates/java/bean.txt
+++ b/src/main/resources/templates/java/bean.txt
@@ -14,7 +14,7 @@ ${importStr}
  * ${currentType.description}
  */
 <% }
-if (currentType instanceof de.lisaplus.atlas.model.EnumType) {
+if (currentType.isEnum) {
 %>public enum ${ upperCamelCase.call(currentType.name) } {
     <% boolean first=true; currentType.allowedValues.each { value ->
     if (first) {%>

--- a/src/main/resources/templates/java/interface.txt
+++ b/src/main/resources/templates/java/interface.txt
@@ -5,9 +5,9 @@ package ${extraParam.packageName};
  * ${currentType.description}
  */
 <% }
-//def isEnum = (currentType instanceof de.lisaplus.atlas.model.EnumType)
-//println "isEnum $isEnum to $currentType"
-if (currentType instanceof de.lisaplus.atlas.model.EnumType) {
+// def isTypeEnum = currentType.isEnum
+// println "isTypeEnum $isTypeEnum to ${currentType.name}"
+if (currentType.isEnum) {
 %>public enum ${ upperCamelCase.call(currentType.name) } {
     <% boolean first=true; currentType.allowedValues.each { value ->
     if (first) {%>
@@ -28,7 +28,7 @@ public interface I${ firstUpperCase.call(currentType.name) } {
     <%
     def isEnum = false
     if(prop.isRefTypeOrComplexType()) {
-       isEnum = (prop.type.type instanceof de.lisaplus.atlas.model.EnumType)
+       isEnum = (prop.type.type.isEnum)
        //println "${prop.type.type} with name ${prop.name} isEnum $isEnum"
     }
     if (isEnum) {

--- a/src/main/resources/templates/java/interface.txt
+++ b/src/main/resources/templates/java/interface.txt
@@ -4,7 +4,20 @@ package ${extraParam.packageName};
 /**
  * ${currentType.description}
  */
-<% } %>
+<% }
+//def isEnum = (currentType instanceof de.lisaplus.atlas.model.EnumType)
+//println "isEnum $isEnum to $currentType"
+if (currentType instanceof de.lisaplus.atlas.model.EnumType) {
+%>public enum ${ upperCamelCase.call(currentType.name) } {
+    <% boolean first=true; currentType.allowedValues.each { value ->
+    if (first) {%>
+    ${value}
+    <% first=false} else { %>
+    ,${value}
+    <% } } %>
+}
+<% } else {
+%>
 public interface I${ firstUpperCase.call(currentType.name) } {
     <% currentType.properties.each { prop -> %>
     <% if (prop.description) { %>
@@ -12,7 +25,20 @@ public interface I${ firstUpperCase.call(currentType.name) } {
      * ${prop.description}
      */
     <% } %>
-    public ${ typeToJava.call(prop.type,'I') } get${ firstUpperCase.call(prop.name) } ();
+    <%
+    def isEnum = false
+    if(prop.isRefTypeOrComplexType()) {
+       isEnum = (prop.type.type instanceof de.lisaplus.atlas.model.EnumType)
+       //println "${prop.type.type} with name ${prop.name} isEnum $isEnum"
+    }
+    if (isEnum) {
+    %>
+    public ${ typeToJava.call(prop.type) } get${ firstUpperCase.call(prop.name) } ();
+    public void set${ firstUpperCase.call(prop.name) } (${ typeToJava.call(prop.type) } ${prop.name});
+    <% } else { %>
+     public ${ typeToJava.call(prop.type,'I') } get${ firstUpperCase.call(prop.name) } ();
     public void set${ firstUpperCase.call(prop.name) } (${ typeToJava.call(prop.type,'I') } ${prop.name});
     <% } %>
+    <% } %>
 }
+<% } %>

--- a/src/main/resources/templates/java/mongo_bean.txt
+++ b/src/main/resources/templates/java/mongo_bean.txt
@@ -70,7 +70,7 @@ public class ${ upperCamelCase.call(currentType.name) } {
         // handle complex types
         <% currentType.properties.findAll {prop -> return prop.isRefTypeOrComplexType() }.each { prop -> %>
             <% if (prop.type.isArray) { %>
-        newObj.${prop.name} = ${ prop.type.type.name }.createArrayFromDocument((java.util.List<Document>)document.get(${toUpperCase.call(prop.name)}));
+        newObj.${prop.name} = ${ prop.type.type.name }.createArrayFromDocument((java.util.Collection<? extends Document>)document.get(${toUpperCase.call(prop.name)}));
             <% } else { %>
         newObj.${prop.name} = ${ typeToJava.call(prop.type) }.createFromDocument((Document)document.get(${toUpperCase.call(prop.name)}));
             <% } %>
@@ -79,7 +79,7 @@ public class ${ upperCamelCase.call(currentType.name) } {
     }
     <% } %>
 
-    public static java.util.List<${ upperCamelCase.call(currentType.name) }> createArrayFromDocument(java.util.List<Document> documentList) {
+    public static java.util.Collection<? extends ${ upperCamelCase.call(currentType.name) }> createArrayFromDocument(java.util.Collection<? extends Document> documentList) {
         if (documentList==null) return null;
         ArrayList<${ upperCamelCase.call(currentType.name) }> ret = new ArrayList<>();
         for (Document document: documentList) {

--- a/src/main/resources/templates/java/sub/mongo_bean_joined_crud.txt
+++ b/src/main/resources/templates/java/sub/mongo_bean_joined_crud.txt
@@ -10,7 +10,7 @@
         // handle complex types
         <% actObj.properties.findAll {prop -> return prop.isRefTypeOrComplexType() }.each { prop -> %>
             <% if (prop.type.isArray) { %>
-        newObj.${prop.name} = ${ prop.type.type.name }.createArrayFromDocument((java.util.List<Document>)document.get(${toUpperCase.call(prop.name)}));
+        newObj.${prop.name} = ${ prop.type.type.name }.createArrayFromDocument((java.util.Collection<? extends Document>)document.get(${toUpperCase.call(prop.name)}));
             <% } else { %>
         newObj.${prop.name} = ${ typeToJava.call(prop.type) }.createFromDocument((Document)document.get(${toUpperCase.call(prop.name)}));
             <% } %>
@@ -40,7 +40,7 @@
     // byId
     public static ${ upperCamelCase.call(actObj.name) } byId (String guid) throws SerializationException {
         MongoCollection collection = getCollection();
-        java.util.List<Bson> aggregations  = new ArrayList<>();
+        java.util.Collection<? extends Bson> aggregations  = new ArrayList<>();
         <% actObj.properties.find { prop -> return prop.hasTag('join') && prop.implicitRefIsRefType() }.each { prop -> %>
         aggregations.add(Aggregates.match(Filters.eq(${ toUpperCase.call(prop.name) }, guid)));
         aggregations.add(Aggregates.lookup(${ upperCamelCase.call(prop.implicitRef.type.name) }.COLLECTION_NAME,${ toUpperCase.call(prop.implicitRef.type.name) }_JOINID,"_id","${ lowerCamelCase.call(prop.implicitRef.type.name) }"));
@@ -67,7 +67,7 @@
      * @return
      * @throws SerializationException
      */
-    public static java.util.List<${ upperCamelCase.call(actObj.name) }> list () throws SerializationException {
+    public static java.util.Collection<? extends ${ upperCamelCase.call(actObj.name) }> list () throws SerializationException {
         return list(-1,-1);
     }
 
@@ -78,9 +78,9 @@
      * @return
      * @throws SerializationException
      */
-    public static java.util.List<${ upperCamelCase.call(actObj.name) }> list (int skip, int limit) throws SerializationException {
+    public static java.util.Collection<? extends ${ upperCamelCase.call(actObj.name) }> list (int skip, int limit) throws SerializationException {
         MongoCollection collection = getCollection();
-        java.util.List<Bson> aggregations  = new ArrayList<>();
+        java.util.Collection<? extends Bson> aggregations  = new ArrayList<>();
 
         <% actObj.properties.find { prop -> return prop.hasTag('join') && prop.implicitRefIsRefType() }.each { prop -> %>
         aggregations.add(Aggregates.lookup(${ upperCamelCase.call(prop.implicitRef.type.name) }.COLLECTION_NAME,${ toUpperCase.call(prop.implicitRef.type.name) }_JOINID,"_id","${ lowerCamelCase.call(prop.implicitRef.type.name) }"));

--- a/src/main/resources/templates/java/sub/mongo_bean_normal_crud.txt
+++ b/src/main/resources/templates/java/sub/mongo_bean_normal_crud.txt
@@ -22,7 +22,7 @@
     // byId
     public static ${ upperCamelCase.call(actObj.name) } byId (String guid) throws SerializationException {
         MongoCollection collection = getCollection();
-        java.util.List<Bson> aggregations  = new ArrayList<>();
+        java.util.Collection<? extends Bson> aggregations  = new ArrayList<>();
         aggregations.add(Aggregates.match(Filters.eq("guid", guid)));
         AggregateIterable iterable = collection.aggregate(
                 aggregations
@@ -44,7 +44,7 @@
      * @return
      * @throws SerializationException
      */
-    public static java.util.List<${ upperCamelCase.call(actObj.name) }> list () throws SerializationException {
+    public static java.util.Collection<? extends ${ upperCamelCase.call(actObj.name) }> list () throws SerializationException {
         return list (-1,-1);
     }
 
@@ -55,9 +55,9 @@
      * @return
      * @throws SerializationException
      */
-    public static java.util.List<${ upperCamelCase.call(actObj.name) }> list (int skip, int limit) throws SerializationException {
+    public static java.util.Collection<? extends ${ upperCamelCase.call(actObj.name) }> list (int skip, int limit) throws SerializationException {
         MongoCollection collection = getCollection();
-        java.util.List<Bson> aggregations  = new ArrayList<>();
+        java.util.Collection<? extends Bson> aggregations  = new ArrayList<>();
         if (skip>0) {
             aggregations.add(Aggregates.skip(skip));
         }

--- a/src/test/groovy/de/lisaplus/atlas/builder/test/jsonschema/JsonSchemaBuilder.groovy
+++ b/src/test/groovy/de/lisaplus/atlas/builder/test/jsonschema/JsonSchemaBuilder.groovy
@@ -5,7 +5,6 @@ import de.lisaplus.atlas.codegen.external.ExtSingleFileGenarator
 import de.lisaplus.atlas.codegen.test.DoCodeGen
 import de.lisaplus.atlas.model.AggregationType
 import de.lisaplus.atlas.model.ByteType
-import de.lisaplus.atlas.model.EnumType
 import de.lisaplus.atlas.model.IntType
 import de.lisaplus.atlas.model.LongType
 import de.lisaplus.atlas.model.RefType
@@ -59,9 +58,10 @@ class JsonSchemaBuilder {
         def grantsEnumType = model.types.find { it.name == 'GrantsEnum'}
         assertNotNull(grantsEnumType)
         List<String> expected1 = ['read','write','commit']
-        assertEquals(expected1.size(),((EnumType)grantsEnumType).allowedValues.size())
+        assertTrue(grantsEnumType.isEnum)
+        assertEquals(expected1.size(),grantsEnumType.allowedValues.size())
         for (int i=0; i<expected1.size();i++) {
-            assertEquals(expected1[i],((EnumType)grantsEnumType).allowedValues[i])
+            assertEquals(expected1[i],grantsEnumType.allowedValues[i])
         }
 
         def userLogType = model.types.find { it.name == 'UserLogType'}
@@ -73,9 +73,10 @@ class JsonSchemaBuilder {
         assertTrue ( userLogTypeProp.type instanceof RefType )
         assertEquals('UserLogType', userLogTypeProp.type.type.name )
         List<String> expected2 = ['login','logout']
-        assertEquals(expected2.size(),((EnumType)userLogType).allowedValues.size())
+        assertTrue(userLogType.isEnum)
+        assertEquals(expected2.size(),userLogType.allowedValues.size())
         for (int i=0; i<expected2.size();i++) {
-            assertEquals(expected2[i],((EnumType)userLogType).allowedValues[i])
+            assertEquals(expected2[i],userLogType.allowedValues[i])
         }
     }
 

--- a/src/test/resources/test_schemas/ds/user.json
+++ b/src/test/resources/test_schemas/ds/user.json
@@ -1,183 +1,183 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "User model",
-  "description": "Test user model",
-  "definitions": {
-    "user_log": {
-      "type": "object",
-      "properties": {
-        "domain_id": {
-          "description": "what is the related domain",
-          "type": "string",
-          "format": "uuid",
-          "__ref": "./shared/domain.json"
-        },
-        "user_id": {
-          "description": "What user owns this entry",
-          "type": "string",
-          "format": "uuid",
-          "__ref": "#/definitions/user"
-        },
-        "domains": {
-          "description": "dummy to test UUID arrays",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "uuid",
-            "__ref": "./shared/domain.json"
-          }
-        },
-        "type": {
-          "description": "type of the entry",
-          "type": "string",
-          "enum": [
-            "login",
-            "logout"
-          ]
-        },
-        "comment": {
-          "description": "the common field contain all unmodeled stuff",
-          "type": "string"
-        }
-      }
-    },
-    "user": {
-      "type": "object",
-      "properties": {
-        "domain_id": {
-          "description": "what is the related domain",
-          "type": "string",
-          "format": "uuid",
-          "__ref": "./shared/domain.json"
-        },
-        "name": {
-          "description": "login name of the user",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-        },
-        "real_name": {
-          "description": "used to display the user in applications",
-          "type": "string",
-          "__visKey": true
-        },
-        "gid": {
-          "type": "string",
-          "format": "uuid"
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/role"
-          }
-        },
-        "active": {
-          "description": "is this entry still active",
-          "type": "boolean"
-        },
-        "comment": {
-          "description": "the common field contain all unmodeled stuff",
-          "type": "string"
-        }
-      },
-      "__tags": [
-        "five",
-        "six",
-        "seven"
-      ]
-    },
-    "role": {
-      "type": "object",
-      "properties": {
-        "domain_id": {
-          "description": "what is the related domain",
-          "type": "string",
-          "format": "uuid",
-            "__ref": "./shared/domain.json"
-        },
-        "name": {
-          "description": "Name of the role",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-        },
-        "comment": {
-          "description": "the common field contain all unmodeled stuff",
-          "type": "string"
-        },
-        "module_grants": {
-          "type": "array",
-          "items": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "User model",
+    "description": "Test user model",
+    "definitions": {
+        "user_log": {
             "type": "object",
-            "description": "what is granted to do with specific modules",
             "properties": {
-              "module": {
-                "$ref": "./shared/app_module.json"
-              },
-              "grant": {
-                "type": "string",
-                "enum": [
-                  "read",
-                  "write",
-                  "commit"
-                ],
-                "__enumName": "GrantsEnum"
-              }
+                "domain_id": {
+                    "description": "what is the related domain",
+                    "type": "string",
+                    "format": "uuid",
+                    "__ref": "./shared/domain.json"
+                },
+                "user_id": {
+                    "description": "What user owns this entry",
+                    "type": "string",
+                    "format": "uuid",
+                    "__ref": "#/definitions/user"
+                },
+                "domains": {
+                    "description": "dummy to test UUID arrays",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uuid",
+                        "__ref": "./shared/domain.json"
+                    }
+                },
+                "type": {
+                    "description": "type of the entry",
+                    "type": "string",
+                    "enum": [
+                        "login",
+                        "logout"
+                    ]
+                },
+                "comment": {
+                    "description": "the common field contain all unmodeled stuff",
+                    "type": "string"
+                }
+            }
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "domain_id": {
+                    "description": "what is the related domain",
+                    "type": "string",
+                    "format": "uuid",
+                    "__ref": "./shared/domain.json"
+                },
+                "name": {
+                    "description": "login name of the user",
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                },
+                "real_name": {
+                    "description": "used to display the user in applications",
+                    "type": "string",
+                    "__visKey": true
+                },
+                "gid": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/role"
+                    }
+                },
+                "active": {
+                    "description": "is this entry still active",
+                    "type": "boolean"
+                },
+                "comment": {
+                    "description": "the common field contain all unmodeled stuff",
+                    "type": "string"
+                }
             },
             "__tags": [
-              "five",
-              "six",
-              "seven"
+                "five",
+                "six",
+                "seven"
             ]
-          },
-          "__tags": [
-            "one",
-            "two"
-          ]
         },
-        "data_grants": {
-          "type": "array",
-          "items": {
+        "role": {
             "type": "object",
-            "description": "what is granted to do with specific modules",
             "properties": {
-              "data_path": {
-                "description" : "dummy string to define some data",
-                "type": "string"
-              },
-              "grant": {
-                "type": "string",
-                "enum": [
-                  "read",
-                  "write",
-                  "commit"
-                ],
-                "__enumName": "GrantsEnum",
-                "__tags": [
-                  "one",
-                  "two"
-                ]
-              },
-              "byteTest": {
-                "type": "integer",
-                "format": "byte"
-              },
-              "byteArrayTest": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "byte"
+                "domain_id": {
+                    "description": "what is the related domain",
+                    "type": "string",
+                    "format": "uuid",
+                    "__ref": "./shared/domain.json"
+                },
+                "name": {
+                    "description": "Name of the role",
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                },
+                "comment": {
+                    "description": "the common field contain all unmodeled stuff",
+                    "type": "string"
+                },
+                "module_grants": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "description": "what is granted to do with specific modules",
+                        "properties": {
+                            "module": {
+                                "$ref": "./shared/app_module.json"
+                            },
+                            "grant": {
+                                "type": "string",
+                                "enum": [
+                                    "read",
+                                    "write",
+                                    "commit"
+                                ],
+                                "__enumName": "GrantsEnum"
+                            }
+                        },
+                        "__tags": [
+                            "five",
+                            "six",
+                            "seven"
+                        ]
+                    },
+                    "__tags": [
+                        "one",
+                        "two"
+                    ]
+                },
+                "data_grants": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "description": "what is granted to do with specific modules",
+                        "properties": {
+                            "data_path": {
+                                "description": "dummy string to define some data",
+                                "type": "string"
+                            },
+                            "grant": {
+                                "type": "string",
+                                "enum": [
+                                    "read",
+                                    "write",
+                                    "commit"
+                                ],
+                                "__enumName": "GrantsEnum",
+                                "__tags": [
+                                    "one",
+                                    "two"
+                                ]
+                            },
+                            "byteTest": {
+                                "type": "integer",
+                                "format": "byte"
+                            },
+                            "byteArrayTest": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer",
+                                    "format": "byte"
+                                }
+                            }
+                        }
+                    }
+                },
+                "active": {
+                    "description": "is this entry still active",
+                    "type": "boolean"
                 }
-              }
-            }
-          }
-        },
-        "active": {
-          "description": "is this entry still active",
-          "type": "boolean"
+            },
+            "__version": 2
         }
-      },
-      "__version": 2
-    }
-  },
-  "type": "object",
-  "__version": 3
+    },
+    "type": "object",
+    "__version": 3
 }


### PR DESCRIPTION
- Enums must be classes even in case of interfaces generation
- use more generic Collection class with extends for the rawType to allow choosing type instead of using lists always.